### PR TITLE
Add SQLAlchemy models and repository for SQLite database

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,79 @@
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy.sql import func
+
+DATABASE_URL = "sqlite:///./botai.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    channel_id = Column(String, unique=True, nullable=False)
+    state = Column(String, nullable=False, default="unverified")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    credits = relationship("Credit", back_populates="user", uselist=False)
+    verification = relationship("Verification", back_populates="user", uselist=False)
+    messages = relationship("Message", back_populates="user")
+
+
+class Credit(Base):
+    __tablename__ = "credits"
+
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
+    initial_credits = Column(Integer, nullable=False)
+    remaining = Column(Integer, nullable=False)
+    milestones_alerted = Column(Text)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    user = relationship("User", back_populates="credits")
+
+
+class Verification(Base):
+    __tablename__ = "verifications"
+
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
+    attempts = Column(Integer, nullable=False, default=0)
+    blocked_until = Column(DateTime(timezone=True), nullable=True)
+
+    user = relationship("User", back_populates="verification")
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    role = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    tokens = Column(Integer)
+    cost = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="messages")
+
+
+def init_db() -> None:
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/db/repo.py
+++ b/db/repo.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from .models import (
+    Message,
+    SessionLocal,
+    User,
+    Credit,
+    Verification,
+)
+
+
+def get_session() -> Session:
+    return SessionLocal()
+
+
+def get_or_create_user(channel_id: str) -> User:
+    with get_session() as session:
+        user = session.query(User).filter_by(channel_id=channel_id).first()
+        if user:
+            return user
+        user = User(channel_id=channel_id, state="unverified")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return user
+
+
+def get_credits(user_id: int) -> Optional[Credit]:
+    with get_session() as session:
+        return session.query(Credit).filter_by(user_id=user_id).first()
+
+
+def ensure_credits(user_id: int, initial: int) -> Credit:
+    with get_session() as session:
+        credit = session.query(Credit).filter_by(user_id=user_id).first()
+        if credit is None:
+            credit = Credit(
+                user_id=user_id,
+                initial_credits=initial,
+                remaining=initial,
+                milestones_alerted="",
+            )
+            session.add(credit)
+            session.commit()
+            session.refresh(credit)
+        return credit
+
+
+def update_credits(user_id: int, remaining: int, milestones_alerted: str) -> None:
+    with get_session() as session:
+        credit = session.query(Credit).filter_by(user_id=user_id).first()
+        if credit is None:
+            credit = Credit(
+                user_id=user_id,
+                initial_credits=remaining,
+                remaining=remaining,
+                milestones_alerted=milestones_alerted,
+            )
+            session.add(credit)
+        else:
+            credit.remaining = remaining
+            credit.milestones_alerted = milestones_alerted
+        session.commit()
+
+
+def get_verification(user_id: int) -> Optional[Verification]:
+    with get_session() as session:
+        return session.query(Verification).filter_by(user_id=user_id).first()
+
+
+def update_verification(
+    user_id: int, attempts: int, blocked_until: Optional[datetime]
+) -> Verification:
+    with get_session() as session:
+        ver = session.query(Verification).filter_by(user_id=user_id).first()
+        if ver is None:
+            ver = Verification(
+                user_id=user_id, attempts=attempts, blocked_until=blocked_until
+            )
+            session.add(ver)
+        else:
+            ver.attempts = attempts
+            ver.blocked_until = blocked_until
+        session.commit()
+        session.refresh(ver)
+        return ver
+
+
+def add_message(
+    user_id: int, role: str, content: str, tokens: Optional[int], cost: int = 0
+) -> Message:
+    with get_session() as session:
+        message = Message(
+            user_id=user_id, role=role, content=content, tokens=tokens, cost=cost
+        )
+        session.add(message)
+        session.commit()
+        session.refresh(message)
+        return message

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 pywhatsapp
 
 python-dotenv
+SQLAlchemy


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for users, credits, verifications and messages
- add repository helpers for user, credit and message operations
- include SQLAlchemy dependency

## Testing
- `python -m pytest`
- `python - <<'PY'
from db.models import init_db
from db.repo import get_or_create_user
init_db()
user = get_or_create_user('chan1')
print(user.channel_id, user.state)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689aab38dbe083238a31bd6fbc9ae5a1